### PR TITLE
Block custom item insertion into cargo nodes

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AbstractFilterNode.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AbstractFilterNode.java
@@ -1,13 +1,21 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.cargo;
 
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
+import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu.AdvancedMenuClickHandler;
+import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ClickAction;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.bakedlibs.dough.items.CustomItemStack;
@@ -37,11 +45,13 @@ abstract class AbstractFilterNode extends AbstractCargoNode {
     protected static final int[] SLOTS = { 19, 20, 21, 28, 29, 30, 37, 38, 39 };
     private static final String FILTER_TYPE = "filter-type";
     private static final String FILTER_LORE = "filter-lore";
+    private final boolean allowCustomItems;
 
     @ParametersAreNonnullByDefault
     protected AbstractFilterNode(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, @Nullable ItemStack recipeOutput) {
         super(itemGroup, item, recipeType, recipe, recipeOutput);
 
+        allowCustomItems = Slimefun.getCfg().getBoolean("options.allow-custom-items-in-cargo-filters");
         addItemHandler(onBreak());
     }
 
@@ -123,6 +133,31 @@ abstract class AbstractFilterNode extends AbstractCargoNode {
                 updateBlockMenu(menu, b);
                 return false;
             });
+        }
+
+        if (!allowCustomItems) {
+            for (int filterSlot : SLOTS) {
+                menu.addMenuClickHandler(filterSlot, new AdvancedMenuClickHandler() {
+                    @Override
+                    public boolean onClick(Player p, int slot, ItemStack item, ClickAction action) {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean onClick(InventoryClickEvent e, Player p, int slot, ItemStack cursor, ClickAction action) {
+                        if (cursor != null) {
+                            SlimefunItem sfItem = SlimefunItem.getByItem(cursor);
+                            if (sfItem == null && !(SlimefunUtils.isItemSimilar(cursor,
+                                    new ItemStack(cursor.getType()), true, false))
+                            ) {
+                                Slimefun.getLocalization().sendMessage(p, "machines.CARGO_NODES.no-custom-items", true);
+                                return false;
+                            }
+                        }
+                        return true;
+                    }
+                });
+            }
         }
 
         addChannelSelector(b, menu, 41, 42, 43);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AbstractFilterNode.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AbstractFilterNode.java
@@ -7,7 +7,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu.AdvancedMenuClickHandler;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ClickAction;
 import org.bukkit.Location;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/CargoNodeListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/CargoNodeListener.java
@@ -43,6 +43,10 @@ public class CargoNodeListener implements Listener {
     public void onFilterMove(InventoryClickEvent e) {
         String invName = e.getWhoClicked().getOpenInventory().getTitle();
         if ((invName.equals("Cargo Node (Input)") || invName.equals("Advanced Cargo Node (Output)"))) {
+            if (Slimefun.getCfg().getBoolean("options.allow-custom-items-in-cargo-filters")) {
+                return;
+            }
+
             if (e.getClick() == ClickType.NUMBER_KEY) {
                 e.setCancelled(true);
                 return;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/CargoNodeListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/CargoNodeListener.java
@@ -1,11 +1,15 @@
 package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 
+import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import javax.annotation.Nonnull;
 
 import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryMoveItemEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
@@ -32,6 +36,28 @@ public class CargoNodeListener implements Listener {
         if ((b.getY() != e.getBlockAgainst().getY() || !e.getBlockReplacedState().getType().isAir()) && isCargoNode(e.getItemInHand())) {
             Slimefun.getLocalization().sendMessage(e.getPlayer(), "machines.CARGO_NODES.must-be-placed", true);
             e.setCancelled(true);
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onFilterMove(InventoryClickEvent e) {
+        String invName = e.getWhoClicked().getOpenInventory().getTitle();
+        if ((invName.equals("Cargo Node (Input)") || invName.equals("Advanced Cargo Node (Output)"))) {
+            if (e.getClick() == ClickType.NUMBER_KEY) {
+                e.setCancelled(true);
+                return;
+            }
+
+            ItemStack item = e.getCurrentItem();
+            if (item == null) {
+                return;
+            }
+
+            SlimefunItem sfItem = SlimefunItem.getByItem(item);
+            if (sfItem == null && item.getItemMeta() != new ItemStack(item.getType()).getItemMeta()) {
+                Slimefun.getLocalization().sendMessage(e.getWhoClicked(), "machines.CARGO_NODES.no-custom-items", true);
+                e.setCancelled(true);
+            }
         }
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,6 +13,7 @@ options:
   legacy-ore-washer: false
   legacy-dust-washer: false
   legacy-ore-grinder: true
+  allow-custom-items-in-cargo-filters: true
   language: en
   enable-translations: true
   log-duplicate-block-entries: true

--- a/src/main/resources/languages/en/messages.yml
+++ b/src/main/resources/languages/en/messages.yml
@@ -315,6 +315,7 @@ machines:
 
   CARGO_NODES:
     must-be-placed: '&4Must be placed onto a chest or machine!'
+    no-custom-items: '&cCustom Items are not allowed in filters!'
 
   INDUSTRIAL_MINER:
     no-fuel: '&cYour Industrial Miner ran out of fuel! Put your fuel into the chest above.'


### PR DESCRIPTION
Note: This is a config option, `allow-custom-items-in-cargo-filters` must be toggled to `false`.