### PR TITLE
No meta compare

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoUtils.java
@@ -396,6 +396,8 @@ final class CargoUtils {
         return network.getItemFilter(node).test(item);
     }
 
+
+
     /**
      * This method checks if a given {@link ItemStack} is smeltable or not.
      * The lazy-option is a performance-saver since actually calculating this can be quite expensive.

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/ItemFilter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/ItemFilter.java
@@ -1,12 +1,17 @@
 package io.github.thebusybiscuit.slimefun4.core.networks.cargo;
 
+import io.github.bakedlibs.dough.items.ItemMetaSnapshot;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import javax.annotation.Nonnull;
 
+import javax.annotation.Nullable;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;
@@ -21,6 +26,7 @@ import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackWrapper;
 import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
+import org.bukkit.inventory.meta.ItemMeta;
 
 /**
  * The {@link ItemFilter} is a performance-optimization for our {@link CargoNet}.
@@ -59,6 +65,7 @@ class ItemFilter implements Predicate<ItemStack> {
      * on the next tick.
      */
     private boolean dirty = false;
+    private boolean checkCustomItems;
 
     /**
      * This creates a new {@link ItemFilter} for the given {@link Block}.
@@ -69,6 +76,7 @@ class ItemFilter implements Predicate<ItemStack> {
      */
     public ItemFilter(@Nonnull Block b) {
         update(b);
+        checkCustomItems = Slimefun.getCfg().getBoolean("options.allow-custom-items-in-cargo-filters");
     }
 
     /**
@@ -200,7 +208,8 @@ class ItemFilter implements Predicate<ItemStack> {
              * and thus only perform .getItemMeta() once
              */
             for (ItemStackWrapper stack : items) {
-                if (SlimefunUtils.isItemSimilar(subject, stack, checkLore, false)) {
+                if ((checkCustomItems && SlimefunUtils.isItemSimilar(subject, stack, checkLore, false)
+                        || (!checkCustomItems && altItemCompare(subject, stack)))) {
                     /*
                      * The filter has found a match, we can return the opposite
                      * of our default value. If we exclude items, this is where we
@@ -215,4 +224,19 @@ class ItemFilter implements Predicate<ItemStack> {
         }
     }
 
+    public static boolean altItemCompare(@Nullable ItemStack item, @Nullable ItemStack sfitem) {
+        if (item == null) {
+            return sfitem == null;
+        }
+
+        if (sfitem == null) {
+            return false;
+        }
+
+        if (sfitem instanceof SlimefunItemStack && item instanceof SlimefunItemStack) {
+            return ((SlimefunItemStack) item).getItemId().equals(((SlimefunItemStack) sfitem).getItemId());
+        } else {
+            return item.getType() == sfitem.getType();
+        }
+    }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,6 +13,7 @@ options:
   legacy-ore-washer: false
   legacy-dust-washer: false
   legacy-ore-grinder: true
+  allow-custom-items-in-cargo-filters: true
   language: en
   enable-translations: true
   log-duplicate-block-entries: true


### PR DESCRIPTION
Adds a config option to skip metadata check when comparing cargo items.