### PR TITLE
fixerror

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/machines/MachineProcessor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/machines/MachineProcessor.java
@@ -251,6 +251,12 @@ public class MachineProcessor<T extends MachineOperation> {
         // Update the progress bar in our inventory (if anyone is watching)
         int remainingTicks = operation.getRemainingTicks();
         int totalTicks = operation.getTotalTicks();
+
+        // If the operation is finished, we don't need to update the progress bar.
+        if (remainingTicks <= 0 && totalTicks <= 0) {
+            return;
+        }
+
         ChestMenuUtils.updateProgressbar(inv, slot, remainingTicks, totalTicks, getProgressBar());
     }
 


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->

We found this issue by accident, but it seems that if Slimefun's ticks are faster than expected, Tier 3 items such as Electric Ore Grinders will produce an ArithmeticException.

https://pastebin.com/ZGWDJyWn - the error from our fork, this small patch fixed it.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Don't update the progress bar if the operation is already finished

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #3538

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
